### PR TITLE
fix: close thread handles after multithreaded search and delete(ui)

### DIFF
--- a/AddressBook/src/control.c
+++ b/AddressBook/src/control.c
@@ -880,8 +880,15 @@ SEARCHRESULT SearchRecordsFromFile_MT(ContactStore* result, const char* input, L
 		if (waitResult == WAIT_TIMEOUT)
 		{
 			printf("ERROR: Search threads did not finish within timeout.\n");
+
+			for (int i = 0; i < 2; i++)
+				CloseHandle(handles[i]);
+
 			return SEARCH_ERROR;
 		}
+
+		for (int i = 0; i < 2; i++)
+			CloseHandle(handles[i]);
 
 		ContactStore_CombineByOp(result, pLeftStore, pRightStore, op);
 

--- a/AddressBook/src/ui.c
+++ b/AddressBook/src/ui.c
@@ -470,7 +470,7 @@ int UI_DeleteNode(LPCWSTR path)
 			fflush(stdout);
 			dotIndex = (dotIndex + 1) % 4;	// Console animation
 		}
-		CloseHandle((HANDLE)hThread);
+		CloseHandle(hThread);
 
 		if (param->result == DELETE_SUCCESS)
 			printf("Record deleted successfully.\n");


### PR DESCRIPTION
- Ensures CloseHandle is called on threads created via _beginthreadex
- Prevents kernel object leaks duting repeated threaded search calls
- Adds handle cleanup to both success and timeout paths

### Summary

Fixes potential kernel handle leak by explicitly closing thread handles created via '_beginthreades`.

### Changes

- Calls `CloseHandle()` after thread completion
- Handles both success and timeout cases
- Prevents resource leak in repeated `SearchRecordFromFile_MT()` usage
- Prevents unnecessary type cast in `UI_DeleteNode()`

### Type
- [x] Bug fix
- [ ]  Feature
- [ ] Refactor