### PR TITLE
fix: refactor delete UI to run background thread with progress feedback

### DIFF
--- a/AddressBook/main.c
+++ b/AddressBook/main.c
@@ -53,6 +53,6 @@ int main(void)
 //	Test_Contact_Destroy();
 //	Test_ContactStore_Destroy();
 //#endif
-//	UI_InsertNode(FILE_PATH_TEST);
+//	UI_DeleteNode(FILE_PATH_TEST);
 //	return 0;
 //}


### PR DESCRIPTION
- Moves record deletion logic to background thread using `_beginthreadex`
- Transfers result via DeleteParam pointer to ensure safe memory communication
- Frees heap-allocated param within thread to avoid leaks